### PR TITLE
Support for player controls (play, pause, volume control)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ futures = "0.3.26"
 futures-util = "0.3.26"
 hyper = {version = "0.14.23", features = ["client", "stream", "tcp", "http1", "http2"]}
 m3u = "1.0.0"
-minimp3 = "0.5.1"
+minimp3 = "0.6"
 owo-colors = "3.5.0"
 pls = "0.2.2"
 prost = "0.13.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -100,6 +100,32 @@ pub enum CurrentDisplayMode {
     None,
 }
 
+impl std::str::FromStr for CurrentDisplayMode {
+    type Err = InvalidDisplayModeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Oscilloscope" => Ok(Self::Oscilloscope),
+            "Vectorscope" => Ok(Self::Vectorscope),
+            "Spectroscope" => Ok(Self::Spectroscope),
+            "None" => Ok(Self::None),
+            _ => Err(InvalidDisplayModeError),
+        }
+    }
+}
+
+/// Invalid display mode error.
+#[derive(Debug)]
+pub struct InvalidDisplayModeError;
+
+impl std::fmt::Display for InvalidDisplayModeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid display mode")
+    }
+}
+
+impl std::error::Error for InvalidDisplayModeError {}
+
 pub struct App {
     #[allow(unused)]
     channels: u8,
@@ -116,6 +142,7 @@ impl App {
         ui: &crate::cfg::UiOptions,
         source: &crate::cfg::SourceOptions,
         frame_rx: Receiver<minimp3::Frame>,
+        mode: CurrentDisplayMode,
     ) -> Self {
         let graph = GraphConfig {
             axis_color: Color::DarkGray,
@@ -145,7 +172,7 @@ impl App {
             oscilloscope,
             vectorscope,
             spectroscope,
-            mode: CurrentDisplayMode::Spectroscope,
+            mode,
             channels: source.channels as u8,
             frame_rx,
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -566,7 +566,7 @@ impl App {
                     | MediaKeyCode::Reverse
                     | MediaKeyCode::FastForward
                     | MediaKeyCode::Rewind
-                    | MediaKeyCode::Record => todo!(),
+                    | MediaKeyCode::Record => {}
                 },
                 _ => {}
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,6 @@ use ratatui::{
 use std::{
     io,
     ops::Range,
-    process,
     sync::{mpsc::Receiver, Arc, Mutex},
     thread,
     time::{Duration, Instant},
@@ -31,6 +30,57 @@ pub struct State {
     pub genre: String,
     pub description: String,
     pub br: String,
+}
+
+/// Volume of the player.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Volume {
+    /// Raw volume.
+    volume: f32,
+    /// Is muted?
+    is_muted: bool,
+}
+
+impl Volume {
+    /// Create a new [`Volume`].
+    pub const fn new(volume: f32, is_muted: bool) -> Self {
+        Self { volume, is_muted }
+    }
+
+    /// Get the current volume. Returns `0.0` if muted.
+    pub const fn volume(&self) -> f32 {
+        if self.is_muted {
+            0.0
+        } else {
+            1.0
+        }
+    }
+
+    /// Is volume muted?
+    pub const fn is_muted(&self) -> bool {
+        self.is_muted
+    }
+
+    /// Toggle mute.
+    pub const fn toggle_mute(&mut self) {
+        self.is_muted = !self.is_muted;
+    }
+
+    /// Change the volume by the given step.
+    ///
+    /// To increase the volume, use a positive step. To decrease the
+    /// volume, use a negative step.
+    pub const fn change_volume(&mut self, step: f32) {
+        self.volume += step;
+        // limit to 0 volume, no upper bound
+        self.volume = self.volume.max(0.0);
+    }
+}
+
+impl Default for Volume {
+    fn default() -> Self {
+        Self::new(1.0, false)
+    }
 }
 
 pub enum CurrentDisplayMode {

--- a/src/app.rs
+++ b/src/app.rs
@@ -58,6 +58,11 @@ impl Volume {
         }
     }
 
+    /// Get the raw volume.
+    pub const fn raw_volume(&self) -> f32 {
+        self.volume
+    }
+
     /// Is volume muted?
     pub const fn is_muted(&self) -> bool {
         self.is_muted
@@ -234,9 +239,9 @@ fn render_frame(state: Arc<Mutex<State>>, frame: &mut Frame) {
     render_line(
         "Volume ",
         &if state.volume.is_muted() {
-            format!("{} muted", state.volume.volume())
+            format!("{} muted", state.volume.raw_volume())
         } else {
-            format!("{}", state.volume.volume())
+            format!("{}", state.volume.raw_volume())
         },
         Rect {
             x: size.x,

--- a/src/app.rs
+++ b/src/app.rs
@@ -341,7 +341,15 @@ impl App {
                     0..self.graph.width * 2,
                 ),
                 KeyCode::Char('q') => quit = true,
-                KeyCode::Char(' ') => self.graph.pause = !self.graph.pause,
+                KeyCode::Char(' ') => {
+                    self.graph.pause = !self.graph.pause;
+                    let sink_cmd = if self.graph.pause {
+                        SinkCommand::Pause
+                    } else {
+                        SinkCommand::Play
+                    };
+                    sink_cmd_tx.send(sink_cmd).expect("receiver never dropped");
+                }
                 KeyCode::Char('s') => self.graph.scatter = !self.graph.scatter,
                 KeyCode::Char('h') => self.graph.show_ui = !self.graph.show_ui,
                 KeyCode::Char('r') => self.graph.references = !self.graph.references,
@@ -368,19 +376,25 @@ impl App {
                 }
                 KeyCode::Media(media_key_code) => match media_key_code {
                     MediaKeyCode::Play => {
+                        self.graph.pause = false;
                         sink_cmd_tx
                             .send(SinkCommand::Play)
                             .expect("receiver never dropped");
                     }
                     MediaKeyCode::Pause => {
+                        self.graph.pause = true;
                         sink_cmd_tx
                             .send(SinkCommand::Pause)
                             .expect("receiver never dropped");
                     }
                     MediaKeyCode::PlayPause => {
-                        sink_cmd_tx
-                            .send(SinkCommand::PlayPause)
-                            .expect("receiver never dropped");
+                        self.graph.pause = !self.graph.pause;
+                        let sink_cmd = if self.graph.pause {
+                            SinkCommand::Pause
+                        } else {
+                            SinkCommand::Play
+                        };
+                        sink_cmd_tx.send(sink_cmd).expect("receiver never dropped");
                     }
                     MediaKeyCode::Stop => {
                         quit = true;

--- a/src/app.rs
+++ b/src/app.rs
@@ -341,8 +341,7 @@ impl App {
                     self.graph.scale = 1.;
                 }
                 KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    let _ = tui::restore();
-                    process::exit(0);
+                    quit = true;
                 }
                 KeyCode::Tab => {
                     // switch modes

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+use app::CurrentDisplayMode;
 use clap::{arg, Command};
 
 mod app;
@@ -46,7 +47,8 @@ A simple CLI to listen to radio stations"#,
             Command::new("play")
                 .about("Play a radio station")
                 .arg(arg!(<station> "The station to play"))
-                .arg(arg!(--volume "Set the initial volume (as a percent)").default_value("100")),
+                .arg(arg!(--volume "Set the initial volume (as a percent)").default_value("100"))
+                .arg(clap::Arg::new("display-mode").long("display-mode").help("Set the display mode to start with").default_value("Spectroscope")),
         )
         .subcommand(
             Command::new("browse")
@@ -92,7 +94,12 @@ async fn main() -> Result<(), Error> {
             let station = args.value_of("station").unwrap();
             let provider = matches.value_of("provider").unwrap();
             let volume = args.value_of("volume").unwrap().parse::<f32>().unwrap();
-            play::exec(station, provider, volume).await?;
+            let display_mode = args
+                .value_of("display-mode")
+                .unwrap()
+                .parse::<CurrentDisplayMode>()
+                .unwrap();
+            play::exec(station, provider, volume, display_mode).await?;
         }
         Some(("browse", args)) => {
             let category = args.value_of("category");

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,8 @@ A simple CLI to listen to radio stations"#,
         .subcommand(
             Command::new("play")
                 .about("Play a radio station")
-                .arg(arg!(<station> "The station to play")),
+                .arg(arg!(<station> "The station to play"))
+                .arg(arg!(--volume "Set the initial volume (as a percent)").default_value("100")),
         )
         .subcommand(
             Command::new("browse")
@@ -90,7 +91,8 @@ async fn main() -> Result<(), Error> {
         Some(("play", args)) => {
             let station = args.value_of("station").unwrap();
             let provider = matches.value_of("provider").unwrap();
-            play::exec(station, provider).await?;
+            let volume = args.value_of("volume").unwrap().parse::<f32>().unwrap();
+            play::exec(station, provider, volume).await?;
         }
         Some(("browse", args)) => {
             let category = args.value_of("category");

--- a/src/play.rs
+++ b/src/play.rs
@@ -121,13 +121,6 @@ pub async fn exec(name_or_id: &str, provider: &str) -> Result<(), Error> {
                     SinkCommand::Pause => {
                         sink.pause();
                     }
-                    SinkCommand::PlayPause => {
-                        if sink.is_paused() {
-                            sink.play();
-                        } else {
-                            sink.pause();
-                        }
-                    }
                 }
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -147,6 +140,4 @@ pub enum SinkCommand {
     Play,
     /// Pause.
     Pause,
-    /// Toggle between play and pause.
-    PlayPause,
 }

--- a/src/play.rs
+++ b/src/play.rs
@@ -4,7 +4,7 @@ use anyhow::Error;
 use hyper::header::HeaderValue;
 
 use crate::{
-    app::{App, State},
+    app::{App, State, Volume},
     cfg::{SourceOptions, UiOptions},
     decoder::Mp3Decoder,
     provider::{radiobrowser::Radiobrowser, tunein::Tunein, Provider},
@@ -91,6 +91,7 @@ pub async fn exec(name_or_id: &str, provider: &str) -> Result<(), Error> {
                     .to_str()
                     .unwrap()
                     .to_string(),
+                volume: Volume::default(),
             })
             .unwrap();
         let location = response.headers().get("location");
@@ -121,6 +122,9 @@ pub async fn exec(name_or_id: &str, provider: &str) -> Result<(), Error> {
                     SinkCommand::Pause => {
                         sink.pause();
                     }
+                    SinkCommand::SetVolume(volume) => {
+                        sink.set_volume(volume);
+                    }
                 }
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -140,4 +144,6 @@ pub enum SinkCommand {
     Play,
     /// Pause.
     Pause,
+    /// Set the volume.
+    SetVolume(f32),
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,10 @@
 use std::io::{self, stderr, stdout, Stdout};
 
-use crossterm::{execute, terminal::*};
+use crossterm::{
+    event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
+    execute,
+    terminal::*,
+};
 use ratatui::prelude::*;
 
 /// A type alias for the terminal type used in this application
@@ -10,7 +14,15 @@ pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 pub fn init() -> io::Result<Tui> {
     execute!(stdout(), EnterAlternateScreen)?;
     execute!(stderr(), EnterAlternateScreen)?;
+    if let Ok(true) = crossterm::terminal::supports_keyboard_enhancement() {
+        execute!(
+            stdout(),
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        )?;
+    }
+
     enable_raw_mode()?;
+
     Terminal::new(CrosstermBackend::new(stdout()))
 }
 
@@ -18,6 +30,11 @@ pub fn init() -> io::Result<Tui> {
 pub fn restore() -> io::Result<()> {
     execute!(stdout(), LeaveAlternateScreen)?;
     execute!(stderr(), LeaveAlternateScreen)?;
+    if let Ok(true) = crossterm::terminal::supports_keyboard_enhancement() {
+        execute!(stdout(), PopKeyboardEnhancementFlags)?;
+    }
+
     disable_raw_mode()?;
+
     Ok(())
 }


### PR DESCRIPTION
Thank you for making this tool :)

## Changes

* Add support for play & pause using spacebar (`KeyCode::Char(' ')`) and media keys

* Add support for volume control using up and down arrow keys and media keys and muting using `m`

  Volume is displayed to the user as a percentage with indication of muted when user mutes.

* Add CLI arguments `--volume` and `--display-mode` under `play` subcommand

* Update `minimp3` to `0.6`

  `minimp3` used to depend on `slice-deque` which is unmaintained and
contains memory safety issues, see https://github.com/germangb/minimp3-rs/issues/42. `minimp3` now uses `slice-ring-buffer`. Used to panic in debug mode.

## Note

Media keys should work in theory but `crossterm` may have a bug currently, see https://github.com/crossterm-rs/crossterm/issues/897. Tested with `alacritty` but didn't work.

