### PR TITLE
OS media controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +731,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
+name = "cocoa"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +849,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
 name = "coreaudio-rs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,7 +912,7 @@ dependencies = [
  "stdweb",
  "thiserror 1.0.69",
  "web-sys",
- "windows",
+ "windows 0.37.0",
 ]
 
 [[package]]
@@ -949,6 +1009,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-crossroads"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4c83437187544ba5142427746835061b330446ca8902eabd70e4afb8f76de0"
+dependencies = [
+ "dbus",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1069,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "displaydoc"
@@ -1109,6 +1195,21 @@ name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2016,6 +2117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2230,15 @@ name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
@@ -2416,6 +2535,15 @@ name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "object"
@@ -3385,6 +3513,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "souvlaki"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5855c8f31521af07d896b852eaa9eca974ddd3211fc2ae292e58dda8eb129bc8"
+dependencies = [
+ "base64 0.22.1",
+ "block",
+ "cocoa",
+ "core-graphics",
+ "dbus",
+ "dbus-crossroads",
+ "dispatch",
+ "objc",
+ "thiserror 1.0.69",
+ "windows 0.44.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,6 +4381,7 @@ dependencies = [
  "rodio",
  "rustfft",
  "serde",
+ "souvlaki",
  "surf",
  "symphonia",
  "termion",
@@ -4567,6 +4714,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4604,6 +4760,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
@@ -4635,6 +4806,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -4653,6 +4830,12 @@ checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -4668,6 +4851,12 @@ name = "windows_i686_gnu"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4695,6 +4884,12 @@ checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -4713,6 +4908,12 @@ checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -4722,6 +4923,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4740,6 +4947,12 @@ name = "windows_x86_64_msvc"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ tonic-reflection = "0.12.3"
 tonic-web = "0.12.3"
 tunein = "0.1.3"
 url = "2.3.1"
+souvlaki = "0.8.3"
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -354,6 +354,11 @@ impl App {
             self.os_media_controls.as_mut(),
             os_media_controls::Command::Play,
         );
+        // report volume to OS
+        send_os_media_controls_command(
+            self.os_media_controls.as_mut(),
+            os_media_controls::Command::SetVolume(new_state.volume.volume_ratio() as f64),
+        );
 
         let new_state = Arc::new(Mutex::new(new_state));
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -429,7 +429,17 @@ impl App {
                 }
             }
 
-            while event::poll(Duration::from_millis(0)).unwrap() {
+            let timeout_duration = if self.graph.pause {
+                // reduce checks to only every 100 milliseconds (~10
+                // times a second). This helps reduce spinning of the
+                // thread and thus consuming a lot of resources while
+                // allowing for event handling at a decent rate.
+                Duration::from_millis(100)
+            } else {
+                Duration::from_millis(0)
+            };
+
+            while event::poll(timeout_duration).unwrap() {
                 // process all enqueued events
                 let event = event::read().unwrap();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -321,6 +321,24 @@ impl App {
         id: &str,
     ) {
         let new_state = cmd_rx.recv().await.unwrap();
+
+        // report metadata to OS
+        send_os_media_controls_command(
+            self.os_media_controls.as_mut(),
+            os_media_controls::Command::SetMetadata(souvlaki::MediaMetadata {
+                title: (!new_state.now_playing.is_empty()).then_some(&new_state.now_playing),
+                album: (!new_state.name.is_empty()).then_some(&new_state.name),
+                artist: None,
+                cover_url: None,
+                duration: None,
+            }),
+        );
+        // report started playing to OS
+        send_os_media_controls_command(
+            self.os_media_controls.as_mut(),
+            os_media_controls::Command::Play,
+        );
+
         let new_state = Arc::new(Mutex::new(new_state));
 
         let id = id.to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod extract;
+pub mod os_media_controls;
 pub mod provider;
 pub mod types;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Error;
 use app::CurrentDisplayMode;
-use clap::{arg, Command};
+use clap::{arg, builder::ValueParser, Command};
 
 mod app;
 mod browse;
@@ -48,7 +48,8 @@ A simple CLI to listen to radio stations"#,
                 .about("Play a radio station")
                 .arg(arg!(<station> "The station to play"))
                 .arg(arg!(--volume "Set the initial volume (as a percent)").default_value("100"))
-                .arg(clap::Arg::new("display-mode").long("display-mode").help("Set the display mode to start with").default_value("Spectroscope")),
+                .arg(clap::Arg::new("display-mode").long("display-mode").help("Set the display mode to start with").default_value("Spectroscope"))
+                .arg(clap::Arg::new("enable-os-media-controls").long("enable-os-media-controls").help("Should enable OS media controls?").default_value("true").value_parser(ValueParser::bool())),
         )
         .subcommand(
             Command::new("browse")
@@ -99,7 +100,15 @@ async fn main() -> Result<(), Error> {
                 .unwrap()
                 .parse::<CurrentDisplayMode>()
                 .unwrap();
-            play::exec(station, provider, volume, display_mode).await?;
+            let enable_os_media_controls = args.get_one("enable-os-media-controls").unwrap();
+            play::exec(
+                station,
+                provider,
+                volume,
+                display_mode,
+                *enable_os_media_controls,
+            )
+            .await?;
         }
         Some(("browse", args)) => {
             let category = args.value_of("category");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Error;
 use app::CurrentDisplayMode;
 use clap::{arg, builder::ValueParser, Command};
@@ -49,7 +51,9 @@ A simple CLI to listen to radio stations"#,
                 .arg(arg!(<station> "The station to play"))
                 .arg(arg!(--volume "Set the initial volume (as a percent)").default_value("100"))
                 .arg(clap::Arg::new("display-mode").long("display-mode").help("Set the display mode to start with").default_value("Spectroscope"))
-                .arg(clap::Arg::new("enable-os-media-controls").long("enable-os-media-controls").help("Should enable OS media controls?").default_value("true").value_parser(ValueParser::bool())),
+                .arg(clap::Arg::new("enable-os-media-controls").long("enable-os-media-controls").help("Should enable OS media controls?").default_value("true").value_parser(ValueParser::bool()))
+                .arg(clap::Arg::new("poll-events-every").long("poll-events-every").help("Poll for events every specified milliseconds.").default_value("16"))
+                .arg(clap::Arg::new("poll-events-every-while-paused").long("poll-events-every-while-paused").help("Poll for events every specified milliseconds while player is paused.").default_value("100")),
         )
         .subcommand(
             Command::new("browse")
@@ -101,12 +105,22 @@ async fn main() -> Result<(), Error> {
                 .parse::<CurrentDisplayMode>()
                 .unwrap();
             let enable_os_media_controls = args.get_one("enable-os-media-controls").unwrap();
+            let poll_events_every =
+                Duration::from_millis(args.value_of("poll-events-every").unwrap().parse().unwrap());
+            let poll_events_every_while_paused = Duration::from_millis(
+                args.value_of("poll-events-every-while-paused")
+                    .unwrap()
+                    .parse()
+                    .unwrap(),
+            );
             play::exec(
                 station,
                 provider,
                 volume,
                 display_mode,
                 *enable_os_media_controls,
+                poll_events_every,
+                poll_events_every_while_paused,
             )
             .await?;
         }

--- a/src/os_media_controls.rs
+++ b/src/os_media_controls.rs
@@ -1,0 +1,36 @@
+//! Operating system level media controls.
+
+use tokio::sync::mpsc::UnboundedReceiver;
+
+/// Operating system level media controls.
+#[derive(Debug)]
+pub struct OsMediaControls {
+    /// Controls that interface with the OS.
+    controls: souvlaki::MediaControls,
+    /// Receiver for events produced by OS level interaction.
+    event_receiver: UnboundedReceiver<souvlaki::MediaControlEvent>,
+}
+
+impl OsMediaControls {
+    /// Create new [`OsMediaControls`].
+    pub fn new() -> Result<Self, souvlaki::Error> {
+        let mut controls = souvlaki::MediaControls::new(souvlaki::PlatformConfig {
+            display_name: "tunein-cli",
+            dbus_name: "tsirysndr.tunein-cli",
+            // TODO: support windows platform
+            hwnd: None,
+        })?;
+
+        let (event_sender, event_receiver) =
+            tokio::sync::mpsc::unbounded_channel::<souvlaki::MediaControlEvent>();
+
+        controls.attach(move |event| {
+            event_sender.send(event).expect("receiver always alive");
+        })?;
+
+        Ok(Self {
+            controls,
+            event_receiver,
+        })
+    }
+}

--- a/src/os_media_controls.rs
+++ b/src/os_media_controls.rs
@@ -33,4 +33,36 @@ impl OsMediaControls {
             event_receiver,
         })
     }
+
+    /// Try to receive event produced by the operating system.
+    ///
+    /// Is [`None`] if no event is produced.
+    pub fn try_recv_os_event(&mut self) -> Option<souvlaki::MediaControlEvent> {
+        self.event_receiver.try_recv().ok()
+    }
+
+    /// Send the given [`Command`] to the operating system.
+    pub fn send_to_os(&mut self, command: Command) -> Result<(), souvlaki::Error> {
+        match command {
+            Command::Play => self
+                .controls
+                .set_playback(souvlaki::MediaPlayback::Playing { progress: None }),
+            Command::Pause => self
+                .controls
+                .set_playback(souvlaki::MediaPlayback::Paused { progress: None }),
+            Command::SetVolume(volume) => self.controls.set_volume(volume),
+            Command::SetMetadata(metadata) => self.controls.set_metadata(metadata),
+        }
+    }
+}
+
+/// Commands understood by OS media controls.
+#[derive(Debug, Clone)]
+pub enum Command<'a> {
+    Play,
+    Pause,
+    /// Volume must be between `0.0..=1.0`.
+    SetVolume(f64),
+    /// Set the [`souvlaki::MediaMetadata`].
+    SetMetadata(souvlaki::MediaMetadata<'a>),
 }

--- a/src/os_media_controls.rs
+++ b/src/os_media_controls.rs
@@ -50,7 +50,26 @@ impl OsMediaControls {
             Command::Pause => self
                 .controls
                 .set_playback(souvlaki::MediaPlayback::Paused { progress: None }),
-            Command::SetVolume(volume) => self.controls.set_volume(volume),
+            Command::SetVolume(volume) => {
+                // NOTE: is supported only for MPRIS backend,
+                // `souvlaki` doesn't provide a way to know this, so
+                // need to use `cfg` attribute like the way it exposes
+                // the platform
+                #[cfg(all(
+                    unix,
+                    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+                ))]
+                {
+                    self.controls.set_volume(volume)
+                }
+                #[cfg(not(all(
+                    unix,
+                    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+                )))]
+                {
+                    Ok(())
+                }
+            }
             Command::SetMetadata(metadata) => self.controls.set_metadata(metadata),
         }
     }

--- a/src/play.rs
+++ b/src/play.rs
@@ -17,6 +17,7 @@ pub async fn exec(
     provider: &str,
     volume: f32,
     display_mode: CurrentDisplayMode,
+    enable_os_media_controls: bool,
 ) -> Result<(), Error> {
     let _provider = provider;
     let provider: Box<dyn Provider> = match provider {
@@ -58,14 +59,18 @@ pub async fn exec(
         tune: None,
     };
 
-    let os_media_controls = OsMediaControls::new()
-        .inspect_err(|err| {
-            eprintln!(
-                "error: failed to initialize os media controls due to `{}`",
-                err
-            );
-        })
-        .ok();
+    let os_media_controls = if enable_os_media_controls {
+        OsMediaControls::new()
+            .inspect_err(|err| {
+                eprintln!(
+                    "error: failed to initialize os media controls due to `{}`",
+                    err
+                );
+            })
+            .ok()
+    } else {
+        None
+    };
 
     let mut app = App::new(&ui, &opts, frame_rx, display_mode, os_media_controls);
     let station_name = station.name.clone();

--- a/src/play.rs
+++ b/src/play.rs
@@ -18,6 +18,8 @@ pub async fn exec(
     volume: f32,
     display_mode: CurrentDisplayMode,
     enable_os_media_controls: bool,
+    poll_events_every: Duration,
+    poll_events_every_while_paused: Duration,
 ) -> Result<(), Error> {
     let _provider = provider;
     let provider: Box<dyn Provider> = match provider {
@@ -72,7 +74,15 @@ pub async fn exec(
         None
     };
 
-    let mut app = App::new(&ui, &opts, frame_rx, display_mode, os_media_controls);
+    let mut app = App::new(
+        &ui,
+        &opts,
+        frame_rx,
+        display_mode,
+        os_media_controls,
+        poll_events_every,
+        poll_events_every_while_paused,
+    );
     let station_name = station.name.clone();
 
     thread::spawn(move || {

--- a/src/play.rs
+++ b/src/play.rs
@@ -2,6 +2,7 @@ use std::{thread, time::Duration};
 
 use anyhow::Error;
 use hyper::header::HeaderValue;
+use tunein_cli::os_media_controls::OsMediaControls;
 
 use crate::{
     app::{App, CurrentDisplayMode, State, Volume},
@@ -57,7 +58,16 @@ pub async fn exec(
         tune: None,
     };
 
-    let mut app = App::new(&ui, &opts, frame_rx, display_mode);
+    let os_media_controls = OsMediaControls::new()
+        .inspect_err(|err| {
+            eprintln!(
+                "error: failed to initialize os media controls due to `{}`",
+                err
+            );
+        })
+        .ok();
+
+    let mut app = App::new(&ui, &opts, frame_rx, display_mode, os_media_controls);
     let station_name = station.name.clone();
 
     thread::spawn(move || {


### PR DESCRIPTION
## Changes

* Add support for operating system level media controls
  * Uses `souvlaki` crate to add cross platform support for OS media controls. Information such as song metadata, play, pause and volume is shared between OS and `tunein-cli`.
  * User can use `--enable-os-media-controls false` command line argument to disable OS media controls, is on by default.

* Add `--poll-events-every` and `--poll-events-every-while-paused` CLI arguments to reduce resource consumption
  * Allows specifying milliseconds to wait before polling for events during play and paused situations.
  * Helps reduce resource consumption with the trade off being responsiveness and animation smoothness.
    * Non scientific testing, CPU single thread consumption dropped from ~40% to ~6% during playback and from ~100% to ~4% when paused with no noticeable difference in responsiveness.
  * Defaults are picked as 16ms and 100ms respectively to ensure smooth animation (~60 FPS) and responsiveness while not wasting compute resources.
  * NOTE: waiting for an event with a timeout does not affect audio playback since it is running on a separate thread.

* Fixed panic caused due to player thread returning before main thread
  There was an `unwrap()` on a channel receiver that receives from player thread. So when closing the program, if the player thread exits earlier, it would panic on the `unwrap()`.

## Note

* Only tested on Linux, specifically `Debian GNU/Linux 12 (bookworm) x86_64, kernel 6.1.0-37-amd64`
  * In theory, macOS should also be supported but see TODO which indicates that without a `winit` (like) event loop it might not be possible to have it. I don't have a macOS system to test it on.
  * Windows is explicitly not supported due to requiring a window open to initialize any media controls. It might be possible to get the window of the terminal and use that to establish the OS media controls. Since I don't have a system to test it on at the moment, haven't added support for it.
  
* Look into `termion` dependency, it appears to be unused but might prevent compilation on Windows.

* It might make sense to introduce a config file instead of using only command line arguments.
  Number of user adjustable parameters is only growing, so having a config file would be better.