### PR TITLE
fix: [spectroscope] pad chunk to sample_size to prevent out of bound read

### DIFF
--- a/src/visualization/spectroscope.rs
+++ b/src/visualization/spectroscope.rs
@@ -131,6 +131,15 @@ impl DisplayMode for Spectroscope {
 
         for (n, chan_queue) in self.buf.iter().enumerate().rev() {
             let mut chunk = chan_queue.iter().flatten().copied().collect::<Vec<f64>>();
+            // sometimes we'll be handed a buffer smaller than the spectroscope's size
+            // this happens if (for example) we've been handed a static mp3, not a livestream
+            // a good repro is getting a station that returns either of these error mp3s:
+            //  - https://cdn-cms.tunein.com/service/Audio/georestricted.enUS.mp3
+            //  - https://cdn-cms.tunein.com/service/Audio/notcompatible.enUS.mp3
+            // (darkwave radomir [s340893] does this in the UK if you connect via VPN with tunein/pull/1 applied)
+            if chunk.len() < sample_len as usize {
+                chunk.resize(sample_len as usize, 0.0);
+            }
             if self.window {
                 chunk = hann_window(chunk.as_slice());
             }


### PR DESCRIPTION
Error streams returned by tunein use 576 as their sample size, rather than the full 1152. This is a simple patch to ensure the Spectrogram never reads out of bounds.

A better fix could be to treat the buffer size *as* the sample size, rather than using the fixed value... but I haven't found a case in which normal playback can trigger this case.

NB: Currently the reproduction case to cause the crash requires #29 to be fixed (otherwise you'll crash earlier :stuck_out_tongue: )

tests: green locally; I figured this is minor and doesn't require new unit testing, but happy to add tests to the spectrogram to prevent this regressing in future