### PR TITLE
feat: add fzf-style fuzzy finder popup to the TUIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ tokio = { version = "1.36.0", features = [
   "macros",
   "rt",
   "rt-multi-thread",
+  "time",
 ] }
 tonic = "0.12.3"
 tonic-reflection = "0.12.3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,15 +18,22 @@ use crate::{
     decoder::Frame as AudioFrame,
     eq_ui::EqPopup,
     extract::get_currently_playing,
+    fzf_ui::{FzfOutcome, FzfPopup},
     help_ui::{HelpPopup, Shortcut},
     input::stream_to_matrix,
     play::SinkCommand,
+    provider::{radiobrowser::Radiobrowser, tunein::Tunein, Provider},
     tui,
+    types::Station,
     visualization::{
         oscilloscope::Oscilloscope, spectroscope::Spectroscope, vectorscope::Vectorscope,
         Dimension, DisplayMode, GraphConfig,
     },
 };
+
+/// How long the fuzzy finder waits after the last keystroke before it fires
+/// a provider search, so fast typing doesn't hammer the network.
+const FZF_DEBOUNCE: Duration = Duration::from_millis(180);
 
 /// Shortcut table shown by the `?` popup in the player TUI.
 const PLAYER_SHORTCUTS: &[Shortcut] = &[
@@ -38,6 +45,7 @@ const PLAYER_SHORTCUTS: &[Shortcut] = &[
     ("↑ / ↓", "Volume up / down (also zooms the scope)"),
     ("← / →", "Show fewer / more samples"),
     ("e", "Open the equalizer"),
+    ("/", "Search stations and switch"),
     ("m", "Mute / unmute"),
     ("s", "Toggle scatter mode"),
     ("h", "Toggle the header UI"),
@@ -50,7 +58,7 @@ const PLAYER_SHORTCUTS: &[Shortcut] = &[
 
 /// Compact status line pinned to the bottom row of the player TUI.
 const PLAYER_STATUS_LINE: &str =
-    "space play/pause • tab mode • ↑/↓ volume • e equalizer • ? help • q quit";
+    "space play/pause • tab mode • ↑/↓ volume • / search • e equalizer • ? help • q quit";
 
 #[derive(Debug, Default, Clone)]
 pub struct State {
@@ -130,6 +138,7 @@ impl Default for Volume {
     }
 }
 
+#[derive(Clone, Copy)]
 pub enum CurrentDisplayMode {
     Oscilloscope,
     Vectorscope,
@@ -173,6 +182,15 @@ pub struct App {
     mode: CurrentDisplayMode,
     eq_popup: EqPopup,
     help_popup: HelpPopup,
+    /// `/` fuzzy finder for searching and switching stations.
+    fzf_popup: FzfPopup,
+    /// The finder's query changed and a search is due once it settles.
+    fzf_dirty: bool,
+    /// When the finder's query was last edited (for debouncing).
+    fzf_last_edit: Instant,
+    /// Set when the user picks a station in the finder; [`Self::run`] returns
+    /// it so the caller can reload playback.
+    next_station: Option<Station>,
     frame_rx: Receiver<AudioFrame>,
     /// [`OsMediaControls`].
     os_media_controls: Option<OsMediaControls>,
@@ -231,6 +249,10 @@ impl App {
             mode,
             eq_popup: EqPopup::new(),
             help_popup: HelpPopup::new(PLAYER_SHORTCUTS),
+            fzf_popup: FzfPopup::new(),
+            fzf_dirty: false,
+            fzf_last_edit: Instant::now(),
+            next_station: None,
             channels: source.channels as u8,
             frame_rx,
             os_media_controls,
@@ -359,14 +381,26 @@ fn render_line(label: &str, value: &str, area: Rect, frame: &mut Frame) {
 }
 
 impl App {
-    /// runs the application's main loop until the user quits
+    /// runs the application's main loop until the user quits or picks a new
+    /// station in the fuzzy finder.
+    ///
+    /// Returns `Some(station)` when the user chose a different station to play
+    /// (the caller reloads playback with it) or `None` when the user quit.
     pub async fn run(
         &mut self,
         terminal: &mut tui::Tui,
         mut cmd_rx: UnboundedReceiver<State>,
         mut sink_cmd_tx: UnboundedSender<SinkCommand>,
         id: &str,
-    ) {
+        provider_name: &str,
+    ) -> Option<Station> {
+        // Provider used by the fuzzy finder to search and to resolve stream URLs.
+        let provider: Option<Box<dyn Provider>> = match provider_name {
+            "tunein" => Some(Box::new(Tunein::new())),
+            "radiobrowser" => Some(Box::new(Radiobrowser::new().await)),
+            _ => None,
+        };
+
         let new_state = cmd_rx.recv().await.unwrap();
 
         let now_playing = new_state.now_playing.clone();
@@ -427,7 +461,7 @@ impl App {
             } else {
                 let Ok(audio_frame) = self.frame_rx.recv() else {
                     // other thread has closed so application has closed
-                    return;
+                    return None;
                 };
                 Some(stream_to_matrix(
                     audio_frame.data.iter().cloned(),
@@ -501,6 +535,7 @@ impl App {
                         );
                         self.eq_popup.render(f);
                         self.help_popup.render(f);
+                        self.fzf_popup.render(f);
                     })
                     .unwrap();
 
@@ -532,7 +567,7 @@ impl App {
                 .and_then(|os_media_controls| os_media_controls.try_recv_os_event())
             {
                 if self.process_os_media_control_event(event, &new_state, &mut sink_cmd_tx) {
-                    return;
+                    return None;
                 }
             }
 
@@ -550,11 +585,35 @@ impl App {
                     .process_events(event.clone(), new_state.clone(), &mut sink_cmd_tx)
                     .unwrap()
                 {
-                    return;
+                    // Either the user quit (`next_station` is `None`) or picked
+                    // a station in the finder (`Some`).
+                    return self.next_station.take();
                 }
-                if let Some(current_display) = self.current_display_mut() {
-                    current_display.handle(event);
+                // The finder swallows keys while open; don't also feed them to
+                // the visualization.
+                if !self.fzf_popup.is_visible() {
+                    if let Some(current_display) = self.current_display_mut() {
+                        current_display.handle(event);
+                    }
                 }
+            }
+
+            // Debounced fuzzy-finder search: once the query settles, ask the
+            // provider and feed the popup fresh candidates.
+            if self.fzf_popup.is_visible()
+                && self.fzf_dirty
+                && self.fzf_last_edit.elapsed() >= FZF_DEBOUNCE
+            {
+                self.fzf_dirty = false;
+                let query = self.fzf_popup.query().trim().to_string();
+                if !query.is_empty() {
+                    if let Some(provider) = &provider {
+                        self.fzf_popup.set_searching(true);
+                        let results = provider.search(query).await.unwrap_or_default();
+                        self.fzf_popup.set_results(results);
+                    }
+                }
+                self.fzf_popup.set_searching(false);
             }
         }
     }
@@ -595,6 +654,22 @@ impl App {
                     KeyCode::Char('c') | KeyCode::Char('q') | KeyCode::Char('w') => quit = true,
                     _ => {}
                 }
+            }
+            // The fuzzy finder captures the whole keyboard while it is open.
+            if self.fzf_popup.is_visible() {
+                match self.fzf_popup.handle_key(key) {
+                    FzfOutcome::QueryChanged => {
+                        self.fzf_dirty = true;
+                        self.fzf_last_edit = Instant::now();
+                    }
+                    FzfOutcome::Submit(station) => {
+                        // Break the loop; `run` returns this station to play.
+                        self.next_station = Some(station);
+                        return Ok(true);
+                    }
+                    FzfOutcome::Close | FzfOutcome::Consumed | FzfOutcome::Ignored => {}
+                }
+                return Ok(quit);
             }
             // While a popup is open it captures the keyboard.
             if self.eq_popup.handle_key(key) || self.help_popup.handle_key(key) {
@@ -639,6 +714,10 @@ impl App {
                 ),
                 KeyCode::Char('e') => self.eq_popup.toggle(),
                 KeyCode::Char('?') => self.help_popup.toggle(),
+                KeyCode::Char('/') => {
+                    self.fzf_popup.open(Vec::new());
+                    self.fzf_dirty = false;
+                }
                 KeyCode::Char('s') => self.graph.scatter = !self.graph.scatter,
                 KeyCode::Char('h') => self.graph.show_ui = !self.graph.show_ui,
                 KeyCode::Char('r') => self.graph.references = !self.graph.references,

--- a/src/fzf_ui.rs
+++ b/src/fzf_ui.rs
@@ -1,0 +1,418 @@
+//! `/` fuzzy finder: a centered, fzf-style modal for searching stations.
+//!
+//! The popup owns only view state — the query, the candidate corpus it was
+//! handed, and the fuzzy-ranked selection. The host ([`crate::interactive`])
+//! feeds it fresh candidates from the provider as the query changes and acts
+//! on whatever the user submits with `enter`.
+
+use std::collections::HashSet;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+use crate::types::Station;
+
+/// Braille spinner frames shown while a provider search is in flight.
+const SPINNER: [char; 8] = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
+
+/// What the host should do after the popup has handled a key.
+pub enum FzfOutcome {
+    /// The popup was not open; the key belongs to the host.
+    Ignored,
+    /// The key was handled; nothing else to do.
+    Consumed,
+    /// The query text changed — the host should (re)run its search.
+    QueryChanged,
+    /// The user picked a station with `enter`.
+    Submit(Station),
+    /// The user dismissed the popup with `esc`.
+    Close,
+}
+
+pub struct FzfPopup {
+    visible: bool,
+    /// The text typed after the `❯` prompt.
+    query: String,
+    /// The candidate corpus most recently handed to the popup.
+    results: Vec<Station>,
+    /// `(index into results, matched char positions in the name)`, best first.
+    matches: Vec<(usize, Vec<usize>)>,
+    state: ListState,
+    /// A provider search is in flight for the current query.
+    searching: bool,
+    /// Advances every frame the spinner is drawn.
+    spinner: usize,
+}
+
+impl FzfPopup {
+    pub fn new() -> Self {
+        Self {
+            visible: false,
+            query: String::new(),
+            results: Vec::new(),
+            matches: Vec::new(),
+            state: ListState::default(),
+            searching: false,
+            spinner: 0,
+        }
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    /// The current query, trimmed of surrounding whitespace.
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    /// Open the finder seeded with an initial candidate list (e.g. the
+    /// favourites or the list currently on screen) so it is useful before
+    /// the first keystroke.
+    pub fn open(&mut self, seed: Vec<Station>) {
+        self.visible = true;
+        self.query.clear();
+        self.searching = false;
+        self.results = seed;
+        self.recompute();
+    }
+
+    pub fn close(&mut self) {
+        self.visible = false;
+        self.searching = false;
+    }
+
+    /// Replace the candidate corpus (typically fresh provider results for the
+    /// current query) and re-rank.
+    pub fn set_results(&mut self, results: Vec<Station>) {
+        self.results = results;
+        self.recompute();
+    }
+
+    pub fn set_searching(&mut self, searching: bool) {
+        self.searching = searching;
+    }
+
+    /// Handle a key while the popup is open.
+    pub fn handle_key(&mut self, key: KeyEvent) -> FzfOutcome {
+        if !self.visible {
+            return FzfOutcome::Ignored;
+        }
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match key.code {
+            KeyCode::Esc => {
+                self.close();
+                FzfOutcome::Close
+            }
+            KeyCode::Enter => match self.selected_station() {
+                Some(station) => {
+                    self.close();
+                    FzfOutcome::Submit(station)
+                }
+                None => FzfOutcome::Consumed,
+            },
+            KeyCode::Down => {
+                self.move_selection(1);
+                FzfOutcome::Consumed
+            }
+            KeyCode::Up => {
+                self.move_selection(-1);
+                FzfOutcome::Consumed
+            }
+            // Emacs-style navigation, familiar from fzf itself.
+            KeyCode::Char('n') if ctrl => {
+                self.move_selection(1);
+                FzfOutcome::Consumed
+            }
+            KeyCode::Char('p') if ctrl => {
+                self.move_selection(-1);
+                FzfOutcome::Consumed
+            }
+            KeyCode::Char('u') if ctrl => {
+                self.query.clear();
+                self.recompute();
+                FzfOutcome::QueryChanged
+            }
+            KeyCode::Backspace => {
+                self.query.pop();
+                self.recompute();
+                FzfOutcome::QueryChanged
+            }
+            KeyCode::Char(c) if !ctrl => {
+                self.query.push(c);
+                self.recompute();
+                FzfOutcome::QueryChanged
+            }
+            _ => FzfOutcome::Consumed,
+        }
+    }
+
+    /// The station under the selection cursor, if any.
+    fn selected_station(&self) -> Option<Station> {
+        let selected = self.state.selected()?;
+        let (index, _) = self.matches.get(selected)?;
+        self.results.get(*index).cloned()
+    }
+
+    fn move_selection(&mut self, delta: i32) {
+        if self.matches.is_empty() {
+            self.state.select(None);
+            return;
+        }
+        let len = self.matches.len() as i32;
+        let current = self.state.selected().unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, len - 1) as usize;
+        self.state.select(Some(next));
+    }
+
+    /// Fuzzy-rank the corpus against the query. An empty query keeps the
+    /// corpus in its original order. Selection jumps back to the top match,
+    /// like fzf does after every edit.
+    fn recompute(&mut self) {
+        let mut scored: Vec<(usize, i32, Vec<usize>)> = self
+            .results
+            .iter()
+            .enumerate()
+            .filter_map(|(i, station)| {
+                fuzzy_match(&self.query, &station.name)
+                    .map(|(score, positions)| (i, score, positions))
+            })
+            .collect();
+        // Higher score first; ties keep the corpus order for stability.
+        scored.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        self.matches = scored.into_iter().map(|(i, _, pos)| (i, pos)).collect();
+
+        if self.matches.is_empty() {
+            self.state.select(None);
+        } else {
+            self.state.select(Some(0));
+        }
+    }
+
+    /// Draw the popup centered over `frame`. Call last so it sits on top.
+    pub fn render(&mut self, frame: &mut Frame) {
+        if !self.visible {
+            return;
+        }
+
+        let size = frame.size();
+        let width = ((size.width as u32 * 80) / 100) as u16;
+        let height = ((size.height as u32 * 75) / 100) as u16;
+        let area = centered_rect(
+            size,
+            width.clamp(24, size.width),
+            height.clamp(6, size.height),
+        );
+        frame.render_widget(Clear, area);
+
+        let block = Block::new()
+            .borders(Borders::ALL)
+            .title(" 🔍 Fuzzy Finder ")
+            .title_alignment(Alignment::Center)
+            .border_style(Style::default().fg(Color::Cyan));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        if inner.height < 3 || inner.width < 4 {
+            return;
+        }
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1), // prompt
+                Constraint::Length(1), // counter
+                Constraint::Min(1),    // results
+            ])
+            .split(inner);
+
+        // Prompt line: `❯ query▌`, with a placeholder before the first keystroke.
+        let mut prompt = vec![Span::styled(
+            "❯ ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )];
+        if self.query.is_empty() {
+            prompt.push(Span::styled(
+                "Type to search stations…",
+                Style::default().fg(Color::DarkGray),
+            ));
+        } else {
+            prompt.push(Span::raw(self.query.clone()));
+            prompt.push(Span::styled(
+                " ",
+                Style::default().add_modifier(Modifier::REVERSED),
+            ));
+        }
+        frame.render_widget(Paragraph::new(Line::from(prompt)), chunks[0]);
+
+        // Counter line: `⣾ 12/240` — spinner (while searching) and match count.
+        let spinner = if self.searching {
+            self.spinner = self.spinner.wrapping_add(1);
+            SPINNER[self.spinner % SPINNER.len()]
+        } else {
+            ' '
+        };
+        let counter = format!(
+            "  {} {}/{}",
+            spinner,
+            self.matches.len(),
+            self.results.len()
+        );
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                counter,
+                Style::default().fg(Color::DarkGray),
+            ))),
+            chunks[1],
+        );
+
+        // Results, with matched characters highlighted.
+        let items: Vec<ListItem> = if self.matches.is_empty() {
+            let message = if self.searching {
+                "Searching…"
+            } else if self.query.is_empty() {
+                "No stations yet — start typing"
+            } else {
+                "No matches"
+            };
+            vec![ListItem::new(Span::styled(
+                message,
+                Style::default().fg(Color::DarkGray),
+            ))]
+        } else {
+            self.matches
+                .iter()
+                .map(|(index, positions)| {
+                    ListItem::new(highlight_line(&self.results[*index], positions))
+                })
+                .collect()
+        };
+        let list = List::new(items).highlight_symbol("❯ ").highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+        frame.render_stateful_widget(list, chunks[2], &mut self.state);
+    }
+}
+
+/// Build the display line for one result, painting the fuzzy-matched
+/// characters of the name and appending its "now playing" subtext.
+fn highlight_line(station: &Station, positions: &[usize]) -> Line<'static> {
+    let matched: HashSet<usize> = positions.iter().copied().collect();
+    let mut spans = Vec::new();
+    let mut run = String::new();
+    let mut run_matched = false;
+
+    for (i, ch) in station.name.chars().enumerate() {
+        let is_match = matched.contains(&i);
+        if !run.is_empty() && is_match != run_matched {
+            spans.push(make_span(&run, run_matched));
+            run.clear();
+        }
+        run.push(ch);
+        run_matched = is_match;
+    }
+    if !run.is_empty() {
+        spans.push(make_span(&run, run_matched));
+    }
+
+    if let Some(playing) = &station.playing {
+        let playing = playing.trim();
+        if !playing.is_empty() {
+            spans.push(Span::styled(
+                format!("  — {}", playing),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+    }
+
+    Line::from(spans)
+}
+
+fn make_span(text: &str, matched: bool) -> Span<'static> {
+    if matched {
+        Span::styled(
+            text.to_string(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::raw(text.to_string())
+    }
+}
+
+/// Fuzzy subsequence match of `query` against `text`, case-insensitive.
+///
+/// Returns `None` when `query` is not a subsequence of `text`; otherwise a
+/// `(score, matched_char_positions)` pair. The scoring rewards consecutive
+/// matches, matches at word boundaries and matches near the start, so the
+/// most fzf-like candidate sorts to the top. An empty query matches
+/// everything with a neutral score.
+pub fn fuzzy_match(query: &str, text: &str) -> Option<(i32, Vec<usize>)> {
+    if query.is_empty() {
+        return Some((0, Vec::new()));
+    }
+
+    let text: Vec<char> = text.chars().collect();
+    let mut positions = Vec::new();
+    let mut score = 0i32;
+    let mut cursor = 0usize;
+    let mut previous: Option<usize> = None;
+
+    for qc in query.chars() {
+        let needle = qc.to_ascii_lowercase();
+        let found = loop {
+            if cursor >= text.len() {
+                return None;
+            }
+            let matches = text[cursor].to_ascii_lowercase() == needle;
+            cursor += 1;
+            if matches {
+                break cursor - 1;
+            }
+        };
+
+        let mut char_score = 1;
+        match previous {
+            Some(prev) if found == prev + 1 => char_score += 5, // adjacent
+            Some(prev) => char_score -= ((found - prev - 1).min(10)) as i32, // gap penalty
+            None => char_score += 10 - (found.min(10) as i32),  // reward an early first hit
+        }
+        // Word-boundary bonus: start of string or after a separator.
+        let boundary = found == 0
+            || matches!(
+                text.get(found - 1),
+                Some(' ') | Some('-') | Some('_') | Some('/') | Some('.') | Some('(')
+            );
+        if boundary {
+            char_score += 3;
+        }
+
+        score += char_score;
+        positions.push(found);
+        previous = Some(found);
+    }
+
+    Some((score, positions))
+}
+
+/// A rect of at most `width`×`height`, centered in `outer`.
+fn centered_rect(outer: Rect, width: u16, height: u16) -> Rect {
+    let w = width.min(outer.width);
+    let h = height.min(outer.height);
+    Rect {
+        x: outer.x + (outer.width - w) / 2,
+        y: outer.y + (outer.height - h) / 2,
+        width: w,
+        height: h,
+    }
+}

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -14,6 +16,7 @@ use crate::audio::{AudioController, PlaybackEvent, PlaybackState};
 use crate::eq_ui::EqPopup;
 use crate::extract::get_currently_playing;
 use crate::favorites::{FavoriteStation, FavoritesStore};
+use crate::fzf_ui::{FzfOutcome, FzfPopup};
 use crate::help_ui::{HelpPopup, Shortcut};
 use crate::provider::{radiobrowser::Radiobrowser, tunein::Tunein, Provider};
 use crate::tui;
@@ -37,6 +40,7 @@ const HUB_SHORTCUTS: &[Shortcut] = &[
     ("d / delete", "Remove favourite (favourites screen)"),
     ("x", "Stop playback"),
     ("+ / -", "Volume up / down"),
+    ("/", "Open the fuzzy finder"),
     ("esc", "Back to the menu"),
     ("?", "Show this help"),
     ("ctrl+c", "Quit"),
@@ -44,9 +48,19 @@ const HUB_SHORTCUTS: &[Shortcut] = &[
 
 const STATUS_TIMEOUT: Duration = Duration::from_secs(3);
 const NOW_PLAYING_POLL_INTERVAL: Duration = Duration::from_secs(10);
+/// How long the fuzzy finder waits after the last keystroke before it fires
+/// a provider search, so fast typing doesn't hammer the network.
+const FZF_DEBOUNCE: Duration = Duration::from_millis(180);
 
 enum HubMessage {
     NowPlaying(String),
+}
+
+/// A debounce timer for the fuzzy finder fired: run the provider search for
+/// this `(generation, query)` unless a newer keystroke has superseded it.
+struct FzfSearchRequest {
+    generation: usize,
+    query: String,
 }
 
 pub async fn run(provider_name: &str) -> Result<(), Error> {
@@ -54,6 +68,7 @@ pub async fn run(provider_name: &str) -> Result<(), Error> {
     let (audio, mut audio_events) = AudioController::new()?;
     let favorites = FavoritesStore::load()?;
     let (metadata_tx, mut metadata_rx) = mpsc::unbounded_channel::<HubMessage>();
+    let (fzf_tx, mut fzf_rx) = mpsc::unbounded_channel::<FzfSearchRequest>();
 
     let mut terminal = tui::init()?;
 
@@ -75,6 +90,7 @@ pub async fn run(provider_name: &str) -> Result<(), Error> {
         audio,
         favorites,
         metadata_tx,
+        fzf_tx,
         os_media_controls,
     );
 
@@ -94,6 +110,9 @@ pub async fn run(provider_name: &str) -> Result<(), Error> {
             }
             Some(message) = metadata_rx.recv() => {
                 app.handle_metadata(message);
+            }
+            Some(request) = fzf_rx.recv() => {
+                app.run_fzf_search(request).await;
             }
         }
 
@@ -134,6 +153,11 @@ struct HubApp {
     os_media_controls: Option<OsMediaControls>,
     eq_popup: EqPopup,
     help_popup: HelpPopup,
+    fzf_popup: FzfPopup,
+    fzf_tx: mpsc::UnboundedSender<FzfSearchRequest>,
+    /// Monotonic tag for the newest fuzzy-finder search; lets in-flight
+    /// searches for stale queries cancel themselves and be discarded.
+    fzf_generation: Arc<AtomicUsize>,
 }
 
 impl HubApp {
@@ -143,6 +167,7 @@ impl HubApp {
         audio: AudioController,
         favorites: FavoritesStore,
         metadata_tx: mpsc::UnboundedSender<HubMessage>,
+        fzf_tx: mpsc::UnboundedSender<FzfSearchRequest>,
         os_media_controls: Option<OsMediaControls>,
     ) -> Self {
         let mut ui = UiState::default();
@@ -164,6 +189,9 @@ impl HubApp {
             os_media_controls,
             eq_popup: EqPopup::new(),
             help_popup: HelpPopup::new(HUB_SHORTCUTS),
+            fzf_popup: FzfPopup::new(),
+            fzf_tx,
+            fzf_generation: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -187,6 +215,7 @@ impl HubApp {
         frame.render_widget(self.render_footer(), areas[3]);
         self.eq_popup.render(frame);
         self.help_popup.render(frame);
+        self.fzf_popup.render(frame);
     }
 
     fn render_header(&self, frame: &mut Frame, area: Rect) {
@@ -654,7 +683,7 @@ impl HubApp {
             }
             Screen::Loading => "Please wait… • x stop playback • Esc cancel • +/- volume".to_string(),
             Screen::Menu => {
-                "↑/↓ navigate • Enter select • e equalizer • x stop playback • Esc back • +/- volume • ? help"
+                "↑/↓ navigate • Enter select • / search • e equalizer • x stop • Esc back • +/- volume • ? help"
                     .to_string()
             }
         }
@@ -736,8 +765,23 @@ impl HubApp {
             return Ok(Action::Quit);
         }
 
+        // The fuzzy finder captures the whole keyboard while it is open.
+        if self.fzf_popup.is_visible() {
+            return self.handle_fzf_key(key);
+        }
+
         // While a popup is open it captures the keyboard.
         if self.eq_popup.handle_key(key) || self.help_popup.handle_key(key) {
+            return Ok(Action::None);
+        }
+
+        // `/` opens the fuzzy finder from anywhere except a text field, where
+        // it is a literal character.
+        if key.code == KeyCode::Char('/')
+            && !key.modifiers.contains(KeyModifiers::CONTROL)
+            && !matches!(self.ui.screen, Screen::SearchInput | Screen::PlayInput)
+        {
+            self.open_fzf();
             return Ok(Action::None);
         }
 
@@ -787,6 +831,96 @@ impl HubApp {
             Screen::BrowseStations { .. } => self.handle_station_list_keys(key, ListKind::Browse),
             Screen::Favourites => self.handle_favourites_keys(key),
             Screen::Loading => Ok(Action::None),
+        }
+    }
+
+    /// Open the fuzzy finder, seeding it with whatever list is most relevant
+    /// to the current screen so `enter` is useful before any typing.
+    fn open_fzf(&mut self) {
+        let seed = match &self.ui.screen {
+            Screen::SearchResults => self.ui.search_results.clone(),
+            Screen::BrowseStations { .. } => self.ui.browse_results.clone(),
+            _ => self
+                .favorites
+                .all()
+                .iter()
+                .map(|fav| Station {
+                    id: fav.id.clone(),
+                    name: fav.name.clone(),
+                    codec: String::new(),
+                    bitrate: 0,
+                    stream_url: String::new(),
+                    playing: None,
+                })
+                .collect(),
+        };
+        self.fzf_popup.open(seed);
+    }
+
+    /// Route a key to the fuzzy finder and act on its outcome. Any selected
+    /// result — favourite, search hit or browse entry — is played directly.
+    fn handle_fzf_key(&mut self, key: KeyEvent) -> Result<Action, Error> {
+        match self.fzf_popup.handle_key(key) {
+            FzfOutcome::QueryChanged => {
+                self.schedule_fzf_search();
+                Ok(Action::None)
+            }
+            FzfOutcome::Submit(station) => {
+                Ok(Action::Task(PendingTask::PlayStation(StationRecord {
+                    provider: self.provider_name.clone(),
+                    station,
+                })))
+            }
+            FzfOutcome::Close | FzfOutcome::Consumed | FzfOutcome::Ignored => Ok(Action::None),
+        }
+    }
+
+    /// Arm a debounce timer for the finder's current query. When it elapses
+    /// (and no newer keystroke has landed) the timer wakes the main loop to
+    /// run the actual search — the provider isn't `Send`, so it can't run in
+    /// the spawned task itself.
+    fn schedule_fzf_search(&mut self) {
+        let query = self.fzf_popup.query().trim().to_string();
+        if query.is_empty() {
+            self.fzf_popup.set_searching(false);
+            return;
+        }
+
+        let generation = self.fzf_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        self.fzf_popup.set_searching(true);
+
+        let tx = self.fzf_tx.clone();
+        let latest = self.fzf_generation.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(FZF_DEBOUNCE).await;
+            // A newer keystroke superseded this one; don't hit the network.
+            if latest.load(Ordering::SeqCst) == generation {
+                let _ = tx.send(FzfSearchRequest { generation, query });
+            }
+        });
+    }
+
+    /// Run a debounced fuzzy-finder search and feed the results back to the
+    /// popup, ignoring stale generations and a finder that has since closed.
+    async fn run_fzf_search(&mut self, request: FzfSearchRequest) {
+        if !self.fzf_popup.is_visible()
+            || request.generation != self.fzf_generation.load(Ordering::SeqCst)
+        {
+            return;
+        }
+
+        let results = self
+            .provider
+            .search(request.query)
+            .await
+            .unwrap_or_default();
+
+        // Guard again: the query may have moved on while we awaited the network.
+        if self.fzf_popup.is_visible()
+            && request.generation == self.fzf_generation.load(Ordering::SeqCst)
+        {
+            self.fzf_popup.set_results(results);
+            self.fzf_popup.set_searching(false);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod eq_ui;
 mod equalizer;
 mod extract;
 mod favorites;
+mod fzf_ui;
 mod help_ui;
 mod input;
 mod interactive;

--- a/src/play.rs
+++ b/src/play.rs
@@ -2,14 +2,16 @@ use std::{process, thread, time::Duration};
 
 use anyhow::Error;
 use hyper::header::HeaderValue;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tunein_cli::os_media_controls::OsMediaControls;
 
 use crate::{
     app::{App, CurrentDisplayMode, State, Volume},
     cfg::{SourceOptions, UiOptions},
-    decoder::StreamDecoder,
+    decoder::{Frame, StreamDecoder},
     provider::{radiobrowser::Radiobrowser, tunein::Tunein, Provider},
     tui,
+    types::Station,
 };
 
 pub async fn exec(
@@ -21,30 +23,22 @@ pub async fn exec(
     poll_events_every: Duration,
     poll_events_every_while_paused: Duration,
 ) -> Result<(), Error> {
-    let _provider = provider;
+    let provider_name = provider.to_string();
     let provider: Box<dyn Provider> = match provider {
         "tunein" => Box::new(Tunein::new()),
         "radiobrowser" => Box::new(Radiobrowser::new().await),
         _ => {
             return Err(anyhow::anyhow!(format!(
                 "Unsupported provider '{}'",
-                provider
+                provider_name
             )))
         }
     };
-    let station = provider.get_station(name_or_id.to_string()).await?;
-    if station.is_none() {
-        return Err(Error::msg("No station found"));
-    }
 
-    let station = station.unwrap();
-    let stream_url = station.stream_url.clone();
-    let id = station.id.clone();
-    let now_playing = station.playing.clone().unwrap_or_default();
-
-    let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel::<State>();
-    let (sink_cmd_tx, mut sink_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<SinkCommand>();
-    let (frame_tx, frame_rx) = std::sync::mpsc::channel::<crate::decoder::Frame>();
+    let mut station = provider
+        .get_station(name_or_id.to_string())
+        .await?
+        .ok_or_else(|| Error::msg("No station found"))?;
 
     let ui = UiOptions {
         scale: 1.0,
@@ -61,29 +55,85 @@ pub async fn exec(
         tune: None,
     };
 
-    let os_media_controls = if enable_os_media_controls {
-        OsMediaControls::new()
-            .inspect_err(|err| {
-                eprintln!(
-                    "error: failed to initialize os media controls due to `{}`",
-                    err
-                );
-            })
-            .ok()
-    } else {
-        None
-    };
+    let mut terminal = tui::init()?;
 
-    let mut app = App::new(
-        &ui,
-        &opts,
-        frame_rx,
-        display_mode,
-        os_media_controls,
-        poll_events_every,
-        poll_events_every_while_paused,
-    );
+    // One iteration per station: the audio thread is bound to a single stream,
+    // so picking a new station in the fuzzy finder tears the old one down and
+    // starts a fresh one.
+    loop {
+        let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel::<State>();
+        let (sink_cmd_tx, sink_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<SinkCommand>();
+        let (frame_tx, frame_rx) = std::sync::mpsc::channel::<Frame>();
+
+        let os_media_controls = if enable_os_media_controls {
+            OsMediaControls::new()
+                .inspect_err(|err| {
+                    eprintln!(
+                        "error: failed to initialize os media controls due to `{}`",
+                        err
+                    );
+                })
+                .ok()
+        } else {
+            None
+        };
+
+        let mut app = App::new(
+            &ui,
+            &opts,
+            frame_rx,
+            display_mode,
+            os_media_controls,
+            poll_events_every,
+            poll_events_every_while_paused,
+        );
+
+        let id = station.id.clone();
+        spawn_audio_thread(&station, volume, cmd_tx, sink_cmd_rx, frame_tx);
+
+        // Kept so the old audio thread can be stopped once `run` returns.
+        let stop_tx = sink_cmd_tx.clone();
+        let next = app
+            .run(&mut terminal, cmd_rx, sink_cmd_tx, &id, &provider_name)
+            .await;
+
+        // Release the current audio device before (maybe) opening another.
+        let _ = stop_tx.send(SinkCommand::Stop);
+
+        match next {
+            Some(picked) => {
+                // Search results carry no stream URL — resolve it before playing.
+                station = if picked.stream_url.is_empty() {
+                    provider
+                        .get_station(picked.id.clone())
+                        .await?
+                        .unwrap_or(picked)
+                } else {
+                    picked
+                };
+            }
+            None => break,
+        }
+    }
+
+    tui::restore()?;
+
+    process::exit(0);
+}
+
+/// Spawn the background thread that fetches `station`'s stream, decodes it and
+/// feeds both the audio sink and the visualizer, until it receives
+/// [`SinkCommand::Stop`].
+fn spawn_audio_thread(
+    station: &Station,
+    volume: f32,
+    cmd_tx: UnboundedSender<State>,
+    mut sink_cmd_rx: UnboundedReceiver<SinkCommand>,
+    frame_tx: std::sync::mpsc::Sender<Frame>,
+) {
+    let stream_url = station.stream_url.clone();
     let station_name = station.name.clone();
+    let now_playing = station.playing.clone().unwrap_or_default();
 
     thread::spawn(move || {
         let client = reqwest::blocking::Client::new();
@@ -165,17 +215,17 @@ pub async fn exec(
                     SinkCommand::SetVolume(volume) => {
                         sink.set_volume(volume);
                     }
+                    SinkCommand::Stop => {
+                        sink.stop();
+                        // Dropping the sink and output stream releases the
+                        // audio device so the next station can take it.
+                        return;
+                    }
                 }
             }
             std::thread::sleep(Duration::from_millis(10));
         }
     });
-
-    let mut terminal = tui::init()?;
-    app.run(&mut terminal, cmd_rx, sink_cmd_tx, &id).await;
-    tui::restore()?;
-
-    process::exit(0);
 }
 
 /// Command for a sink.
@@ -187,4 +237,6 @@ pub enum SinkCommand {
     Pause,
     /// Set the volume.
     SetVolume(f32),
+    /// Stop playback and release the audio device.
+    Stop,
 }


### PR DESCRIPTION

<img width="1466" height="809" alt="Screenshot 2026-07-10 at 11 47 21" src="https://github.com/user-attachments/assets/283e8406-4f3a-4cf8-b613-ec6234f493aa" />

Press `/` to open a centered, fzf-style modal for searching stations, available in both interactive mode and the play/scope TUI. Results are fuzzy-ranked with matched characters highlighted, and any highlighted result plays directly with Enter.

- src/fzf_ui.rs: reusable FzfPopup widget + fuzzy matcher
- interactive: debounced provider search via a timer task, generation- guarded so stale queries are dropped
- play: audio thread is now URL-driven via a Stop command so App::run can return a picked station and reload playback without leaving the TUI
- enable the tokio "time" feature for debounce timers